### PR TITLE
Changing the location provider to one supports https

### DIFF
--- a/client/source/UI/ViewLocation.ts
+++ b/client/source/UI/ViewLocation.ts
@@ -8,7 +8,7 @@ module Imint.Exclusive.Client.UI {
 			this.Title = "Location";
 		}
 		Setup() {
-			this.Append(new Wappli.Browser(() => "http://geomaplookup.net/?iphone=true&ip=" + this.Address));
+			this.Append(new Wappli.Browser(() => "https://db-ib.com/" + this.Address));
 		}
 	}
 }


### PR DESCRIPTION
replacing http://geomaplookup.net with https://db-ip.com
